### PR TITLE
Update to work with lingon 2.2.0

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,9 +10,9 @@ module.exports = function(lingon, config) {
 
   var watchFn = function(callback) {
     gulp.task('default', function(){
-      lingon.log("Go!");
+      lingon.log.info("Go!");
       gulp.watch(config.watchDir, function(){
-        lingon.log("Build triggered by watch");
+        lingon.log.info("Build triggered by watch");
         lingon.build({
           'callback': callback
         });

--- a/package.json
+++ b/package.json
@@ -16,8 +16,10 @@
   "bugs": {
     "url": "https://github.com/nikek/lingon-watch/issues"
   },
+  "peerDependencies": {
+    "lingon": "^2.2.0"
+  },
   "dependencies": {
-    "lingon": "~0.5.3",
     "gulp": "~3.5.6"
   },
   "devDependencies": {},


### PR DESCRIPTION
- The `lingon.log()` method [no longer exists](https://github.com/spotify/lingon/commit/3c9b9208de6a8a01049631d764ab91244878d7a7#diff-7). Replaced with `lingon.log.info()`
- Added `lingon#2.2.0` as a peerDependency, to make sure the correct version of Lingon is used
